### PR TITLE
chore(deps): bump node from 16.2.0-alpine3.13 to 16.3.0-alpine3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.2.0-alpine3.13 AS builder
+FROM node:16.3.0-alpine3.13 AS builder
 
 LABEL org.opencontainers.image.source="https://github.com/jef/streetmerchant"
 
@@ -16,7 +16,7 @@ COPY test/ test/
 RUN npm run compile
 RUN npm prune --production
 
-FROM node:16.2.0-alpine3.13
+FROM node:16.3.0-alpine3.13
 
 RUN apk add --no-cache chromium
 


### PR DESCRIPTION
Bumps node from 16.2.0-alpine3.13 to 16.3.0-alpine3.13.

---
updated-dependencies:
- dependency-name: node
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

<!-- Please use Conventional Commits to label your title -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->
<!-- Example: feat: allow provided config object to extend other configs  -->

### Description

<!-- Fixes #(issue) -->
<!-- Please also include relevant motivation and context. -->

### Testing

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

### New dependencies

<!-- List any dependencies that are required for this change. -->
<!-- Otherwise, delete section. -->
